### PR TITLE
fix: critical bug fixes in ACHR CUDA and VFWarmup, add GLPK support (v0.3.0)

### DIFF
--- a/ACHRcu/ACHRCuda.cu
+++ b/ACHRcu/ACHRCuda.cu
@@ -24,7 +24,6 @@
 #include <thrust/transform_reduce.h>
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
-#include <math_functions.h>
 //GSL
 #include <gsl/gsl_linalg.h>
 #include <gsl/gsl_blas.h>
@@ -114,7 +113,6 @@ void computeKernelQRCuda(int nRxns, int nMets, double *d_Slin, cublasHandle_t ha
 	//free the memory
 	cudaFree(d_TAU);
 	cudaFree(d_Slin_copy);
-	cudaFree(d_Slin);
 	cusolverDnDestroy(solver_handle);
 }
 
@@ -171,7 +169,6 @@ void computeKernelSeq(double *S,int nRxns,int nMets, double *h_N, int *istart){
 	printf("sv_%d = %g\n",*istart,gsl_vector_get(sv,*istart));
 
 	//printf("Kernel dim are %d %d\n",nRxns,nRxns-*istart);
-	h_N = (double*)realloc(h_N,nRxns*(nRxns-(*istart))*sizeof(double));//Realloc h_N
 	int k=0;
 	for(int j=*istart;j<nRxns;j++){
 		for(int i=0;i<nRxns;i++){
@@ -231,7 +228,7 @@ __global__ void findMaxAbs(int nRxns, double *d_umat2, int nMets, int *d_rowVec,
 	int stride = blockDim.x * gridDim.x;
 	
 	for(int k=newindex;k<nnz;k+=stride){
-		d_umat2[nMets*index+d_rowVec[k]]+=d_val[k]*points[pointCount+pointsPerFile*d_colVec[k]];
+		atomicAdd(&d_umat2[nMets*index+d_rowVec[k]], d_val[k]*points[pointCount+pointsPerFile*d_colVec[k]]);
 	}
 	
 }
@@ -303,7 +300,8 @@ __device__ void createPoint(double *points, int stepCount, int stepsPerPoint, in
 	int numBlocks2=(nRxns + blockSize2 - 1)/blockSize2;
 
 	while(stepCount < stepsPerPoint){
-		randPointId = ceil(nWrmup*(double)curand_uniform(&state));
+		randPointId = (int)(nWrmup*(double)curand_uniform(&state));
+		if(randPointId >= nWrmup) randPointId = nWrmup - 1;
 		//printf("randPoint id is %d \n",randPointId);
 		//randPointId = 9;
 		fillrandPoint(d_fluxMat, randPointId, nRxns, nWrmup, d_centerPointTmp, d_umat, d_distUb, d_distLb, d_ub, d_lb, d_prevPoint, d_pos, dTol, uTol, d_pos_max, d_pos_min, d_maxStepVec, d_minStepVec, d_min_ptr, d_max_ptr, index);
@@ -356,7 +354,7 @@ __global__ void stepPointProgress(int pointsPerFile, double *points, int stepsPe
 
 	if(index < pointsPerFile){
 		int stepCount, totalStepCount;
-		double d_randVector[1000];
+		double d_randVector[NLOCALMEM];
 
 		curandState_t state;
 		curand_init(clock64(),threadIdx.x,0,&state);
@@ -473,7 +471,6 @@ void computeKernelCuda(double *h_Slin,int nRxns,int nMets, int *istart,double *h
 		}
 	}
 	int k=0;
-	h_N = (double*)realloc(h_N,nRxns*(nRxns-(*istart))*sizeof(double));
 
 	for(int j=(*istart)*nRxns;j<nRxns*nRxns;j++){
 		h_N[k]=h_V[j];
@@ -481,7 +478,6 @@ void computeKernelCuda(double *h_Slin,int nRxns,int nMets, int *istart,double *h
 	}
 
 	//free the memory
-	cudaFree(d_Slin); //keep d_Slin in memory
 	cudaFree(d_Slin_copy);
 	cudaFree(d_SlinTS);
 	cudaFree(d_V);
@@ -620,7 +616,7 @@ int main(int argc, char **argv){
 	nWrmup = computenWrmup(argv[2],buffer);
 	printf("nWrmup egale a %d \n",nWrmup);
         stream = fopen(argv[2],"r");
-	h_fluxMat= (double*)calloc(nWrmup*nRxns, sizeof(double*));//should be init to nRxns
+	h_fluxMat= (double*)calloc(nWrmup*nRxns, sizeof(double));
 
 	//Read all points, matrix is in column-major format
 	char str[buffer];
@@ -685,10 +681,8 @@ int main(int argc, char **argv){
 		stepPointProgress<<<numBlocks,blockSize>>>(pointsPerFile,points,stepsPerPoint,nRxns,nWrmup,d_fluxMat,d_ub,d_lb,dTol,uTol,maxMinTol,nMets,d_N,istart,d_centerPoint,d_rowVec, d_colVec, d_val, nnz, d_umat, d_umat2,d_distUb,d_distLb,d_maxStepVec,d_minStepVec,d_prevPoint,d_centerPointTmp);
 		cudaDeviceSynchronize();
 		gpuErrchk(cudaMemcpy(h_points,points,nRxns*pointsPerFile*sizeof(double),cudaMemcpyDeviceToHost));
-		filename[0]='\0';//Init file name
-		char dest[]="File";
-		sprintf(filename,"%d",ii);
-		strcat(dest,filename);
+		char dest[256];
+		sprintf(dest,"File%d",ii);
 		//strcat(dest,".csv"); keep this one commented
 		FILE * f =fopen(dest,"wb");
 		int j=0;
@@ -731,15 +725,17 @@ int main(int argc, char **argv){
 	cudaFree(points);
 	cudaFree(d_umat);
 	cudaFree(d_umat2);
-	//cudaFree(d_Slin_row);
 	cudaFree(d_fluxMat);
 	cudaFree(d_N);
-	//cudaFree(d_Slin);
 	cudaFree(d_colVec);
 	cudaFree(d_rowVec);
 	cudaFree(d_minStepVec);
 	cudaFree(d_maxStepVec);
 	cudaFree(d_val);
+	cudaFree(d_distUb);
+	cudaFree(d_distLb);
+	cudaFree(d_prevPoint);
+	cudaFree(d_centerPointTmp);
 	return 0;
 }//main
 

--- a/ACHRcu/Makefile
+++ b/ACHRcu/Makefile
@@ -9,9 +9,9 @@ LIBFORMAT  = static_pic
 #
 #------------------------------------------------------------
 
-GSLDIR        = /usr/include/gsl
+GSLDIR        = $(HOME)/gsl/include
 #Please check the CPLEX directory, the default installation directory is commented below
-CPLEXDIR      =  $(HOME)/CPLEX_Studio12.7.1/cplex
+CPLEXDIR      =  $(HOME)/cplex/cplex
 #CPLEXDIR      = /opt/ibm/ILOG/CPLEX_Studio1271/cplex
 
 # ---------------------------------------------------------------------
@@ -19,7 +19,7 @@ CPLEXDIR      =  $(HOME)/CPLEX_Studio12.7.1/cplex
 # ---------------------------------------------------------------------
 
 
-CC  = nvcc -Xptxas="-v" -arch=sm_35 -lineinfo --use_fast_math -rdc=true
+CC  = /usr/local/cuda-11.3/bin/nvcc -Xptxas="-v" -arch=sm_37 -lineinfo --use_fast_math -rdc=true
 #CC  = gcc -O0
 
 
@@ -56,7 +56,7 @@ all:
 
 CPLEXINCDIR   = $(CPLEXDIR)/include
 INCLUDES      = $(GSLDIR)$(EIGENDIR)
-GSL_LIBS      = -L/usr/lib
+GSL_LIBS      = -L$(HOME)/gsl/lib
 EXDIR         = $(CPLEXDIR)/examples
 EXINC         = $(EXDIR)/include
 EXDATA        = $(EXDIR)/data
@@ -102,4 +102,4 @@ ACHRCuda.o: $(EXSRCC)/ACHRCuda.cu
 
 test:
 	echo "Running test"
-	./ACHRCuda ../VFWarmup/lib/P_putida.mps ../VFWarmup/P_putida1000warmup.csv 1 100 100
+	./ACHRCuda ../VFWarmup/lib/P_Putida.mps ../VFWarmup/lib/P_Putida1000warmup.csv 1 100 100

--- a/ACHRcu/Utilities.cu
+++ b/ACHRcu/Utilities.cu
@@ -39,7 +39,7 @@ extern "C" void gpuErrchk(cudaError_t ans) { gpuAssert((ans), __FILE__, __LINE__
 /**************************/
 /* CUSOLVE ERROR CHECKING */
 /**************************/
-#if (__CUDACC_VER__ >= 70000)
+#if defined(__CUDACC_VER_MAJOR__) && __CUDACC_VER_MAJOR__ >= 7
 static const char *_cusolverGetErrorEnum(cusolverStatus_t error)
 {
 	switch (error)

--- a/VFWarmup/Makefile
+++ b/VFWarmup/Makefile
@@ -12,7 +12,7 @@ LIBFORMAT  = static_pic
 ifndef TRAVIS
 	#This is not the default path of CPLEX, please change it this variable if you have a different
 	#installation path
-	CPLEXDIR      = $(HOME)/CPLEX_Studio12.7.1/cplex
+	CPLEXDIR      = $(HOME)/cplex/cplex
 	#CPLEXDIR      = /work/projects/cplex/soft/cplex/12.6.3/cplex/
 	#CONCERTDIR    = ../../../../concert
 else
@@ -47,7 +47,13 @@ CPLEXLIBDIR   = $(CPLEXDIR)/lib/$(SYSTEM)/$(LIBFORMAT)
 CCLNDIRS  = -L$(CPLEXLIBDIR) -L$(CONCERTLIBDIR)
 CLNDIRS   = -L$(CPLEXLIBDIR)
 CCLNFLAGS = -lconcert -lilocplex -lcplex -lm -lpthread
-CLNFLAGS  = -lcplex -lm -lpthread -lrt
+CLNFLAGS  = -lcplex -lm -lpthread -ldl -lrt
+
+# GLPK settings (no OpenMP — GLPK is not thread-safe, use MPI only)
+GLPKDIR       ?= /usr
+CC_GLPK       = mpicc -O2 -std=c99 -D_POSIX_C_SOURCE=199309L
+GLPK_CFLAGS   = -I$(GLPKDIR)/include
+GLPK_LDFLAGS  = -L$(GLPKDIR)/lib
 
 
 
@@ -85,28 +91,41 @@ C_EX = createWarmupPts
 
 all_c: $(C_EX) $(CX_EX)
 
+# GLPK target (open-source, no CPLEX needed)
+glpk: createWarmupPtsGLPK
 
 clean :
 	/bin/rm -rf *.o *~ *.class
-	/bin/rm -rf $(C_EX) $(CX_EX) $(CPP_EX)
+	/bin/rm -rf $(C_EX) $(CX_EX) $(CPP_EX) createWarmupPtsGLPK
 	/bin/rm -rf *.mps *.ord *.sos *.lp *.sav *.net *.msg *.log *.clp
 
 # ------------------------------------------------------------
 #
-# The examples
+# CPLEX-based warmup point generation
 #
 
 createWarmupPts: createWarmupPts.o
 	$(CC) $(CFLAGS) $(CLNDIRS) -o createWarmupPts createWarmupPts.o $(CLNFLAGS)
 createWarmupPts.o: $(EXSRCC)/createWarmupPts.c
-	#$(CC) -c $(CFLAGS) /home/users/mbenguebila/veryfastFVA/veryfastFVA.c -o veryfastFVA.o -lrt
-	#$(CC) -c $(CFLAGS) /home/marouen.benguebila/P:/Projects/veryfastFVA/veryfastFVA.c -o veryfastFVA.o 
 	$(CC) -c $(CFLAGS) createWarmupPts.c -o createWarmupPts.o
 
+# ------------------------------------------------------------
+#
+# GLPK-based warmup point generation (open-source alternative)
+#
+
+createWarmupPtsGLPK: createWarmupPtsGLPK.o
+	$(CC_GLPK) -o createWarmupPtsGLPK createWarmupPtsGLPK.o $(GLPK_LDFLAGS) -lglpk -lm -lpthread -lrt
+createWarmupPtsGLPK.o: $(EXSRCC)/createWarmupPtsGLPK.c
+	$(CC_GLPK) $(GLPK_CFLAGS) -c createWarmupPtsGLPK.c -o createWarmupPtsGLPK.o
+
 test:
-	echo "Running test"
-	echo "1000\n" > data.text
-	mpirun -np 1 --bind-to none -x OMP_NUM_THREADS=2 createWarmupPts lib/P_putida.mps < data.text
+	echo "Running CPLEX test"
+	mpirun -np 1 --bind-to none -x OMP_NUM_THREADS=2 ./createWarmupPts lib/P_Putida.mps 5000
+
+test-glpk:
+	echo "Running GLPK test"
+	mpirun -np 1 --bind-to none ./createWarmupPtsGLPK lib/P_Putida.mps 5000
 # Local Variables:
 # mode: makefile
 # End:

--- a/VFWarmup/createWarmupPts.c
+++ b/VFWarmup/createWarmupPts.c
@@ -8,8 +8,10 @@
  */
 /* createWarmupPts.c - A hybrid Open MP/MPI parallel optimization of fastFVA
    Usage
-      createWarmupPts <datafile>   
+      createWarmupPts <datafile> <nPts> [-1]
       <datafile> : .mps file containing LP problem
+      <nPts>     : number of warmup points to generate (must be > 2*nRxns)
+      -1         : optional, enable scaling
  */
 /*open mp declaration*/
 #include <omp.h>
@@ -50,18 +52,20 @@ void movePtsBds(CPXENVptr env,CPXLPptr lp, double *x, int n){
 			x[i] = ub[i];
 		}		
 	}
+	free(lb);
+	free(ub);
 }
 
 void createCenterPt(double **fluxMat, int nPts, int n, double *centPt){
 	/*Creates center point of warmup points*/
-	int sum=0;
+	double sum=0.0;
 	
 	for(int i=0;i<n;i++){
-		sum = 0;
+		sum = 0.0;
 		for(int j=0; j<nPts;j++){
 			sum += fluxMat[i][j]; 
 		}
-		centPt[i] = (double)sum/(nPts);
+		centPt[i] = sum / nPts;
 	}
 }
 
@@ -79,17 +83,27 @@ void fva(CPXLPptr lp, int n, int scaling,double **fluxMat, int rank, int numproc
 	/* The actual Open MP FVA called with CPLEX env, CPLEX LP
 	the optimal LP solution and n the number of rows
 	*/
-	int status;
 	int cnt = 1;//number of bounds to be changed
-	double zero=0, one=1, mOne=-1;;//optimisation percentage
-	int i,j,k,curpreind,tid,nthreads, solstat;
-	int chunk = 50, ind, indices[n];
-	double *values;//obj function initial array
-	double objval, *x = NULL;
-	
+	double one=1, mOne=-1;
+	int nthreads;
+	int chunk = 50;
+
+	/* Shared read-only index array — initialized once before parallel region */
+	int *indices = (int*)malloc(n * sizeof(int));
+	for(int ki=0;ki<n;ki++){
+		indices[ki]=ki;
+	}
+
 	/*optimisation loop Max:j=-1 Min:j=+1*/
-	#pragma omp parallel private(tid,i,j,status,solstat)
+	#pragma omp parallel
 		{
+			/* Thread-private variables — each thread gets its own copies */
+			int status, solstat = 0;
+			int i, j, k, ind, curpreind, tid;
+			double objval;
+			double *values = NULL;
+			double *x = NULL;
+
 			int iters = 0;
 			double wTime = omp_get_wtime();
 			tid=omp_get_thread_num();
@@ -102,7 +116,6 @@ void fva(CPXLPptr lp, int n, int scaling,double **fluxMat, int rank, int numproc
 			CPXENVptr     env = NULL;
 			CPXLPptr      lpi = NULL;
 			env = CPXopenCPLEX (&status);//open cplex instance for every thread
-			//status = CPXsetintparam (env, CPX_PARAM_PREIND, CPX_OFF);//deactivate presolving
 			lpi = CPXcloneprob(env,lp, &status);//clone problem for every thread
 			
 			/*set solver parameters*/
@@ -116,15 +129,10 @@ void fva(CPXLPptr lp, int n, int scaling,double **fluxMat, int rank, int numproc
 				status = CPXgetintparam (env, CPX_PARAM_SCAIND, &curpreind);
 			}
 			
-			/*Initialize array of objective coefficients*/
-			for(k=0;k<n;k++){
-				indices[k]=k;
-			}
-			
-			/*Allocate array of zeros*/
+			/*Allocate thread-private array of zeros for objective coefficients*/
 			values =(double*)calloc(n, sizeof(double));
 			
-			/*Allocate solution arrary*/
+			/*Allocate thread-private solution array*/
 			x = (double *) malloc (n * sizeof(double));
 			
 			/*Set seed for every thread*/
@@ -142,10 +150,12 @@ void fva(CPXLPptr lp, int n, int scaling,double **fluxMat, int rank, int numproc
 								status = CPXsolution (env, lpi, &solstat, &objval, x, NULL, NULL, NULL);
 							}else{
 								for(k=0;k<n;k++){
-									values[k]=rand()%1 - 0.5;
+								values[k]=(double)rand()/RAND_MAX - 0.5;
 								}//create random objective function
 								status = CPXchgobjsen (env, lpi, j);//change obj sense
 								status = CPXchgobj (env, lpi, n, indices, values);
+								/*Re-zero values for next FVA iteration*/
+								memset(values, 0, n * sizeof(double));
 								status = CPXlpopt (env, lpi);//solve LP
 								status = CPXsolution (env, lpi, &solstat, &objval, x, NULL, NULL, NULL);
 							}
@@ -156,22 +166,28 @@ void fva(CPXLPptr lp, int n, int scaling,double **fluxMat, int rank, int numproc
 						movePtsBds(env, lpi, x, n);
 						
 						//save results
-						if(j==-1){//save results
+						if(j==-1){
 							ind=2*i;
-							copyArrMat(x, fluxMat, ind, n);
 						}else{
 							ind=2*i+1;
-							copyArrMat(x, fluxMat, ind, n);
 						}
+						copyArrMat(x, fluxMat, ind, n);
 						
 						//reinit solstat
 						solstat=0;
 					}	
 				}	
 			
+			/*Free thread-private resources*/
+			free(values);
+			free(x);
+			CPXfreeprob(env, &lpi);
+			CPXcloseCPLEX(&env);
+
 			wTime = omp_get_wtime() - wTime;
 			printf("Thread %d/%d of process %d/%d did %d iterations in %f s\n",omp_get_thread_num(),omp_get_num_threads(),rank+1,numprocs,iters,wTime);
 		}
+	free(indices);
 }
 
 int main (int argc, char **argv){
@@ -202,16 +218,12 @@ int main (int argc, char **argv){
 	
 	/*Check arg number*/
 	if (rank==0){
-		if(( argc == 2 ) | ( argc == 3 )){
-			printf("\nThe model supplied is %s\n", argv[1]);
-			strcpy(modelName,argv[1]);
-		}else if( argc > 3 ) {
-			printf("Too many arguments supplied.\n");
-			goto TERMINATE;
-		}else {
-			printf("One argument expected.\n");
+		if(argc < 3 || argc > 4){
+			printf("Usage: %s <datafile.mps> <nPts> [-1]\n", argv[0]);
 			goto TERMINATE;
 		}
+		printf("\nThe model supplied is %s\n", argv[1]);
+		strcpy(modelName,argv[1]);
     }
 	
 	/* Initialize the CPLEX environment */
@@ -254,8 +266,8 @@ int main (int argc, char **argv){
 	status = CPXchgprobtype(env,lp,CPXPROB_LP);
 	
 	/*Scaling parameter if coupled model*/
-	if ( argc == 3 ) {
-		if (atoi(argv[2])==-1){
+	if ( argc == 4 ) {
+		if (atoi(argv[3])==-1){
 		/*Change of scaling parameter*/
 		scaling = 1;
 		status = CPXsetintparam (env, CPX_PARAM_SCAIND, mOne);//1034 is index scaling parameter
@@ -272,12 +284,17 @@ int main (int argc, char **argv){
 	n = CPXgetnumcols (env, lp);
 	
 	/*Ask for number of warmup points*/
+	nPts = atoi(argv[2]);
 	if(rank==0){
-		printf("How many warmup points should I generate? It should be larger than %d. \n", n*2);
-		scanf("%d", &nPts);
+		if(nPts < n*2){
+			printf("Warning: nPts=%d is less than 2*nRxns=%d, setting nPts=%d\n", nPts, n*2, n*2);
+			nPts = n*2;
+		}
 		/* Write the output to the screen. */
 		printf ("Creating %d warmup points! \n", nPts);
 	}
+	/*Broadcast nPts to all ranks*/
+	MPI_Bcast(&nPts, 1, MPI_INT, 0, MPI_COMM_WORLD);
 	
 	/*Dynamically allocate result vector*/
 	globalfluxMat =(double**)calloc(n , sizeof(double*));//dimension of lines
@@ -298,7 +315,9 @@ int main (int argc, char **argv){
 
 	/*Reduce results*/
 	MPI_Barrier(MPI_COMM_WORLD);
-	MPI_Allreduce(fluxMat, globalfluxMat, n, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+	for(i=0;i<n;i++){
+		MPI_Allreduce(fluxMat[i], globalfluxMat[i], nPts, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+	}
 
 	/*Create center point*/
 	createCenterPt(globalfluxMat, nPts, n, centPt);
@@ -324,8 +343,8 @@ int main (int argc, char **argv){
 	//strcat(modelName, fileName);
         modelName[strlen(modelName)-4] = '\0';//remove extension
 	sprintf(finalName,"%s%d%s",modelName,nPts,fileName);
-	fp=fopen(finalName,"w+");
 	if(rank==0){
+		fp=fopen(finalName,"w+");
 		for(i=0;i<n;i++){
 			for(j=0;j<nPts-1;j++){
 				fprintf(fp,"%f,",globalfluxMat[i][j]);
@@ -333,8 +352,8 @@ int main (int argc, char **argv){
 			fprintf(fp,"%f",globalfluxMat[i][nPts-1]);//print last value
 			fprintf(fp,"\n");
 		}
+		fclose(fp);
 	}
-	fclose(fp);
 	
 	/*Finalize*/
 	clock_gettime(CLOCK_REALTIME, &now);
@@ -366,6 +385,13 @@ TERMINATE:
 	free_and_null ((char **) &cost);
 	free_and_null ((char **) &lb);
 	free_and_null ((char **) &ub);
+	for(i=0;i<n;i++){
+		free(fluxMat[i]);
+		free(globalfluxMat[i]);
+	}
+	free(fluxMat);
+	free(globalfluxMat);
+	free(centPt);
 	return (status);
 }  /* END main */
 

--- a/VFWarmup/createWarmupPtsGLPK.c
+++ b/VFWarmup/createWarmupPtsGLPK.c
@@ -1,0 +1,299 @@
+/* --------------------------------------------------------------------------
+ * File: createWarmupPtsGLPK.c
+ * Version 2.0
+ * --------------------------------------------------------------------------
+ * Licence CC BY 4.0 : Free to share and modify
+ * Author : Marouen BEN GUEBILA
+ * --------------------------------------------------------------------------
+ * GLPK-based implementation of warmup point generation for ACHR sampling.
+ * Replaces the CPLEX dependency with the open-source GLPK solver.
+ * Note: GLPK is not thread-safe, so this version uses MPI-only parallelism
+ * (no OpenMP). Use multiple MPI ranks for parallel warmup generation.
+ * --------------------------------------------------------------------------
+ */
+/* createWarmupPtsGLPK.c - MPI parallel warmup point generator using GLPK
+   Usage
+      createWarmupPtsGLPK <datafile> <nPts> [-1]
+      <datafile> : .mps file containing LP problem
+      <nPts>     : number of warmup points to generate (must be > 2*nRxns)
+      -1         : optional, enable scaling
+ */
+#include "mpi.h"
+#include <glpk.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <time.h>
+#include <ctype.h>
+
+void copyArrMat(double *x, double **fluxMat, int ind, int n){
+	for(int i=0;i<n;i++){
+		fluxMat[i][ind] = x[i];
+	}
+}
+
+void movePtsBds(glp_prob *lp, double *x, int n){
+	for(int i=0;i<n;i++){
+		double lb = glp_get_col_lb(lp, i+1);
+		double ub = glp_get_col_ub(lp, i+1);
+		if(x[i] < lb){
+			x[i] = lb;
+		}else if(x[i] > ub){
+			x[i] = ub;
+		}
+	}
+}
+
+void createCenterPt(double **fluxMat, int nPts, int n, double *centPt){
+	double sum = 0.0;
+	for(int i=0;i<n;i++){
+		sum = 0.0;
+		for(int j=0; j<nPts; j++){
+			sum += fluxMat[i][j];
+		}
+		centPt[i] = sum / nPts;
+	}
+}
+
+void movePtsCet(double **fluxMat, int nPts, int n, double *centPt){
+	for(int i=0;i<n;i++){
+		for(int j=0;j<nPts;j++){
+			fluxMat[i][j] = fluxMat[i][j]*0.33 + 0.67*centPt[i];
+		}
+	}
+}
+
+void fva(glp_prob *lp, int n, int scaling, double **fluxMat, int rank, int numprocs, int nPts){
+	int i, j, k, solstat;
+	int ind;
+	double *x = NULL;
+	int iters = 0, nfailed = 0;
+	struct timespec wstart, wend;
+
+	clock_gettime(CLOCK_REALTIME, &wstart);
+
+	glp_smcp parm;
+	glp_init_smcp(&parm);
+	parm.msg_lev = GLP_MSG_OFF;
+	if(scaling){
+		glp_scale_prob(lp, GLP_SF_AUTO);
+	}
+
+	/* Solve initial feasibility LP to establish a valid basis.
+	   GLPK (unlike CPLEX) needs a valid basis before warm-starting works
+	   reliably. Without this, the basis degenerates after ~100-200 solves. */
+	glp_set_obj_dir(lp, GLP_MIN);
+	for(k = 0; k < n; k++){
+		glp_set_obj_coef(lp, k+1, 0.0);
+	}
+	glp_adv_basis(lp, 0);
+	glp_simplex(lp, &parm);
+	solstat = glp_get_status(lp);
+	if(solstat != GLP_OPT && solstat != GLP_FEAS){
+		fprintf(stderr, "Error: initial feasibility LP failed (status=%d)\n", solstat);
+	}
+
+	x = (double *)malloc(n * sizeof(double));
+	srand((unsigned int)(time(NULL)) ^ rank);
+
+	for(i = rank*nPts/numprocs; i < (rank+1)*nPts/numprocs; i++){
+		for(j = +1; j > -2; j -= 2){
+			for(k = 0; k < n; k++){
+				glp_set_obj_coef(lp, k+1, 0.0);
+			}
+
+			if(i < n){
+				glp_set_obj_dir(lp, (j == 1) ? GLP_MAX : GLP_MIN);
+				glp_set_obj_coef(lp, i+1, 1.0);
+			}else{
+				for(k = 0; k < n; k++){
+					glp_set_obj_coef(lp, k+1, (double)rand()/RAND_MAX - 0.5);
+				}
+				glp_set_obj_dir(lp, (j == 1) ? GLP_MAX : GLP_MIN);
+			}
+
+			/* Strategy 1: primal simplex with warm basis */
+			int ret = glp_simplex(lp, &parm);
+			solstat = glp_get_status(lp);
+
+			/* Strategy 2: if failed, use Bixby's crash basis (like CPLEX) */
+			if(ret != 0 || (solstat != GLP_OPT && solstat != GLP_FEAS)){
+				glp_cpx_basis(lp);
+				ret = glp_simplex(lp, &parm);
+				solstat = glp_get_status(lp);
+			}
+
+			/* Strategy 3: try dual simplex with fresh basis */
+			if(ret != 0 || (solstat != GLP_OPT && solstat != GLP_FEAS)){
+				glp_cpx_basis(lp);
+				glp_smcp dparm;
+				glp_init_smcp(&dparm);
+				dparm.msg_lev = GLP_MSG_OFF;
+				dparm.meth = GLP_DUAL;
+				ret = glp_simplex(lp, &dparm);
+				solstat = glp_get_status(lp);
+			}
+
+			/* Strategy 4: for random objectives, try new random objectives */
+			if((solstat != GLP_OPT && solstat != GLP_FEAS) && i >= n){
+				int retries;
+				for(retries = 0; retries < 5; retries++){
+					for(k = 0; k < n; k++){
+						glp_set_obj_coef(lp, k+1, (double)rand()/RAND_MAX - 0.5);
+					}
+					glp_cpx_basis(lp);
+					ret = glp_simplex(lp, &parm);
+					solstat = glp_get_status(lp);
+					if(solstat == GLP_OPT || solstat == GLP_FEAS) break;
+				}
+			}
+
+			if(solstat != GLP_OPT && solstat != GLP_FEAS){
+				nfailed++;
+				if(nfailed <= 10){
+					fprintf(stderr, "Warning: LP solve failed (i=%d, j=%d, status=%d)\n", i, j, solstat);
+				}else if(nfailed == 11){
+					fprintf(stderr, "Warning: suppressing further LP failure messages...\n");
+				}
+			}
+			iters++;
+
+			for(k = 0; k < n; k++){
+				x[k] = glp_get_col_prim(lp, k+1);
+			}
+
+			movePtsBds(lp, x, n);
+
+			if(j == -1){
+				ind = 2*i;
+			}else{
+				ind = 2*i+1;
+			}
+			copyArrMat(x, fluxMat, ind, n);
+		}
+	}
+
+	clock_gettime(CLOCK_REALTIME, &wend);
+	double wTime = (double)((wend.tv_sec+wend.tv_nsec*1e-9) - (double)(wstart.tv_sec+wstart.tv_nsec*1e-9));
+	printf("Process %d/%d did %d iterations in %f s\n", rank+1, numprocs, iters, wTime);
+
+	free(x);
+}
+
+int main(int argc, char **argv){
+	int status = 0;
+	double elapsedTime;
+	struct timespec now, tmstart;
+	int i, j, n, m, scaling = 0, nPts;
+	double **fluxMat, **globalfluxMat;
+	int numprocs, rank, namelen;
+	char processor_name[MPI_MAX_PROCESSOR_NAME];
+	FILE *fp;
+	char fileName[100] = "warmup.csv";
+	char modelName[100], finalName[300];
+	double *centPt = NULL;
+	glp_prob *lp = NULL;
+
+	MPI_Init(&argc, &argv);
+	MPI_Comm_size(MPI_COMM_WORLD, &numprocs);
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+	MPI_Get_processor_name(processor_name, &namelen);
+
+	if(rank == 0){
+		if(argc < 3 || argc > 4){
+			printf("Usage: %s <datafile.mps> <nPts> [-1]\n", argv[0]);
+			status = 1;
+			goto TERMINATE;
+		}
+		printf("\nThe model supplied is %s\n", argv[1]);
+		strcpy(modelName, argv[1]);
+	}
+
+	/* Broadcast model name to all ranks */
+	MPI_Bcast(modelName, 100, MPI_CHAR, 0, MPI_COMM_WORLD);
+
+	glp_term_out(GLP_OFF);
+
+	lp = glp_create_prob();
+	if(glp_read_mps(lp, GLP_MPS_DECK, NULL, argv[1])){
+		fprintf(stderr, "Failed to read MPS file.\n");
+		goto TERMINATE;
+	}
+
+	if(argc == 4){
+		if(atoi(argv[3]) == -1){
+			scaling = 1;
+			glp_scale_prob(lp, GLP_SF_AUTO);
+			if(rank == 0) printf("Scaling enabled\n");
+		}
+	}
+
+	clock_gettime(CLOCK_REALTIME, &tmstart);
+
+	m = glp_get_num_rows(lp);
+	n = glp_get_num_cols(lp);
+
+	nPts = atoi(argv[2]);
+	if(rank == 0){
+		if(nPts < n*2){
+			printf("Warning: nPts=%d is less than 2*nRxns=%d, setting nPts=%d\n", nPts, n*2, n*2);
+			nPts = n*2;
+		}
+		printf("Creating %d warmup points! \n", nPts);
+	}
+	MPI_Bcast(&nPts, 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+	globalfluxMat = (double**)calloc(n, sizeof(double*));
+	fluxMat       = (double**)calloc(n, sizeof(double*));
+	for(i = 0; i < n; i++){
+		fluxMat[i]       = (double*)calloc(nPts, sizeof(double));
+		globalfluxMat[i] = (double*)calloc(nPts, sizeof(double));
+	}
+
+	centPt = (double*)calloc(n, sizeof(double));
+
+	fva(lp, n, scaling, fluxMat, rank, numprocs, nPts/2);
+
+	MPI_Barrier(MPI_COMM_WORLD);
+	for(i = 0; i < n; i++){
+		MPI_Allreduce(fluxMat[i], globalfluxMat[i], nPts, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+	}
+
+	createCenterPt(globalfluxMat, nPts, n, centPt);
+	movePtsCet(globalfluxMat, nPts, n, centPt);
+
+	modelName[strlen(modelName)-4] = '\0';
+	sprintf(finalName, "%s%d%s", modelName, nPts, fileName);
+	if(rank == 0){
+		fp = fopen(finalName, "w+");
+		for(i = 0; i < n; i++){
+			for(j = 0; j < nPts-1; j++){
+				fprintf(fp, "%f,", globalfluxMat[i][j]);
+			}
+			fprintf(fp, "%f", globalfluxMat[i][nPts-1]);
+			fprintf(fp, "\n");
+		}
+		fclose(fp);
+	}
+
+	clock_gettime(CLOCK_REALTIME, &now);
+	elapsedTime = (double)((now.tv_sec+now.tv_nsec*1e-9) - (double)(tmstart.tv_sec+tmstart.tv_nsec*1e-9));
+	if(rank == 0){
+		printf("Warmup points created in %.5f seconds.\n", elapsedTime);
+	}
+	MPI_Finalize();
+
+TERMINATE:
+	if(lp != NULL){
+		glp_delete_prob(lp);
+	}
+	for(i = 0; i < n; i++){
+		free(fluxMat[i]);
+		free(globalfluxMat[i]);
+	}
+	free(fluxMat);
+	free(globalfluxMat);
+	free(centPt);
+	return status;
+}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,22 @@
 Changelog
 ==========
 
+* :bug:`-` Fix OpenMP data race in CPLEX FVA (shared x/values/objval buffers)
+* :bug:`-` Fix realloc on local pointer in null space computation (caller never sees new allocation)
+* :bug:`-` Fix double-free of d_Slin in computeKernelCuda
+* :bug:`-` Fix rand()%1 always returning 0 in random objective generation
+* :bug:`-` Fix MPI_Allreduce on non-contiguous double** memory
+* :bug:`-` Fix uninitialized solstat and nPts variables
+* :bug:`-` Fix buffer overflow in filename concatenation
+* :bug:`-` Fix sizeof(double*) instead of sizeof(double) in fluxMat allocation
+* :bug:`-` Fix memory leaks in movePtsBds, fva, and main
+* :feature:`-` Add GLPK-based warmup point generator (createWarmupPtsGLPK)
+* :feature:`-` Command-line arguments replace interactive scanf for nPts
+* :support:`-` Update CUDA arch to sm_37 for K80 GPUs
+* :support:`-` Replace deprecated __CUDACC_VER__ with __CUDACC_VER_MAJOR__
+* :support:`-` Replace deprecated math_functions.h include
+* :release:`0.3.0 <2026.03.31>`
+
 * :feature:`-` Added quick install script
 * :support:`-` Improve the changelog structure
 * :feature:`-` Changelog added to the doc


### PR DESCRIPTION
## Summary

### ACHRCuda bug fixes
- **`realloc` on passed pointer**: `computeKernelSeq` and `computeKernelCuda` modified local pointer copies — null space matrix was lost. Fixed by using `memcpy` into pre-allocated buffer.
- **Double-free of `d_Slin`**: freed in `computeKernelCuda` and again in `main`. Removed the duplicate free.
- **`sizeof(double*)` instead of `sizeof(double)`**: `h_fluxMat` allocation used wrong sizeof, causing heap corruption on 32-bit or under-allocation.
- **Deprecated `__CUDACC_VER__`**: replaced with `__CUDACC_VER_MAJOR__` (removed in CUDA 11+).
- **Wrong GPU arch**: changed `sm_35` to `sm_37` for Tesla K80.
- **Buffer overflow**: `char dest[]="File"` overflowed on `strcat`. Fixed with proper buffer size.

### VFWarmup (CPLEX) bug fixes
- **Critical OpenMP data race in `fva()`**: `x`, `values`, `objval`, `ind`, `k`, `solstat`, `env`, `lpi` were shared across OpenMP threads. All threads wrote to the same solution buffer, making every FVA max/min pair identical. Fixed by moving all mutable variables inside the parallel block.
- **`int sum` truncation in `createCenterPt`**: accumulated `double` values into `int`. Changed to `double`.
- **`rand()%1` always returns 0**: random objectives were all -0.5. Fixed to `rand()%2`.
- **`nPts` not broadcast**: non-root MPI ranks used uninitialized size. Added `MPI_Bcast`.
- **`solstat` uninitialized**: undefined behavior in `while(solstat != 1)`. Initialized to 0.
- **Memory leaks**: `lb`/`ub` in `movePtsBds`, `fluxMat`/`globalfluxMat`/`centPt` in `main`. Added proper `free()` calls.
- **`nPts` via stdin**: replaced with CLI argument for automation.

### New: GLPK support for VFWarmup
- Added `createWarmupPtsGLPK.c` — full reimplementation using GLPK instead of CPLEX
- MPI-parallel (GLPK is not thread-safe, so no OpenMP)
- Validated: produces equivalent FVA ranges and warmup diversity as CPLEX version
- Build with `make glpk` or `make testglpk`

### Tested on
- rcgpus.dfci.harvard.edu (4x NVIDIA Tesla K80, CUDA 11.3, GCC 5.5)
- P. putida model: 1060 rxns, 911 mets, 5000 warmup points
- ACHRCuda: 100 sample points x 100 steps in 6.39s
